### PR TITLE
feat: /users/{userId}/posts GET api 구현

### DIFF
--- a/src/main/java/com/efub/efubtwitterteam3/controller/UserController.java
+++ b/src/main/java/com/efub/efubtwitterteam3/controller/UserController.java
@@ -1,10 +1,13 @@
 package com.efub.efubtwitterteam3.controller;
 
+import com.efub.efubtwitterteam3.dto.PostGetResponseDto;
 import com.efub.efubtwitterteam3.dto.UserRequestDto;
 import com.efub.efubtwitterteam3.dto.UserResponseDto;
 import com.efub.efubtwitterteam3.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -20,5 +23,10 @@ public class UserController {
     @PutMapping("/{userId}")
     public UserResponseDto updateUser(@PathVariable Long userId, @RequestBody UserRequestDto req){
         return userService.updateUser(userId, req);
+    }
+
+    @GetMapping("/{userId}/posts")
+    public List<PostGetResponseDto> findPostsByUser(@PathVariable Long userId){
+        return userService.findPostsByUser(userId);
     }
 }

--- a/src/main/java/com/efub/efubtwitterteam3/domain/PostRepository.java
+++ b/src/main/java/com/efub/efubtwitterteam3/domain/PostRepository.java
@@ -1,8 +1,15 @@
 package com.efub.efubtwitterteam3.domain;
 
+import com.efub.efubtwitterteam3.dto.PostGetResponseDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query("SELECT p FROM Post p WHERE p.user=:user")
+    List<PostGetResponseDto> findUserPostsCustomResponse(User user);
 }

--- a/src/main/java/com/efub/efubtwitterteam3/service/UserService.java
+++ b/src/main/java/com/efub/efubtwitterteam3/service/UserService.java
@@ -1,7 +1,9 @@
 package com.efub.efubtwitterteam3.service;
 
+import com.efub.efubtwitterteam3.domain.PostRepository;
 import com.efub.efubtwitterteam3.domain.User;
 import com.efub.efubtwitterteam3.domain.UserRepository;
+import com.efub.efubtwitterteam3.dto.PostGetResponseDto;
 import com.efub.efubtwitterteam3.dto.UserRequestDto;
 import com.efub.efubtwitterteam3.dto.UserResponseDto;
 import com.efub.efubtwitterteam3.service.error.CustomException;
@@ -10,12 +12,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 
 @RequiredArgsConstructor
 @Service
 public class UserService {
     private final UserRepository userRepository;
+    private final PostRepository postRepository;
 
     @Transactional
     public UserResponseDto findById(Long id){
@@ -34,5 +38,13 @@ public class UserService {
 
         userRepository.save(entity);
         return new UserResponseDto(entity);  // 변경된 유저의 정보를 반환
+    }
+
+    @Transactional
+    public List<PostGetResponseDto> findPostsByUser(Long id){
+        User entity = userRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        return postRepository.findUserPostsCustomResponse(entity);
     }
 }


### PR DESCRIPTION
특정 유저 게시글 반환 api

응답예시:
1. 성공 시
```json
[
    {
        "postId": 1,
        "user": {
            "userId": 1,
            "nickname": "test2",
            "identifier": "testIdentifier",
            "bio": "testtt"
        },
        "date": "2022-05-02T15:10:20",
        "content": "안뇽"
    },
    {
        "postId": 3,
        "user": {
            "userId": 1,
            "nickname": "test2",
            "identifier": "testIdentifier",
            "bio": "testtt"
        },
        "date": "2022-05-02T15:11:28",
        "content": "안뇽"
    }
]
```
2. 존재하는 유저, 작성한 게시글 없을 시
```json
[]
```
3. 존재하지 않는 유저 id로 요청 시(실패)
```json
{
    "status": 404,
    "error": "NOT_FOUND",
    "code": "MEMBER_NOT_FOUND",
    "message": "해당 유저 정보를 찾을 수 없습니다."
}
```